### PR TITLE
Add txn_status support to WebhooksAPI

### DIFF
--- a/src/helius/webhooks.py
+++ b/src/helius/webhooks.py
@@ -12,6 +12,7 @@ class WebhooksAPI:
         transaction_types: list, 
         account_addresses: list, 
         webhook_type: str, 
+        txn_status: str="all",
         auth_header: str=None
         ):
         
@@ -21,7 +22,8 @@ class WebhooksAPI:
             "webhookURL": webhook_url,
             "transactionTypes": transaction_types,
             "accountAddresses": account_addresses,
-            "webhookType": webhook_type
+            "webhookType": webhook_type,
+            "txn_status": txn_status
         }
         if auth_header:
             payload["authHeader"] = auth_header
@@ -47,6 +49,7 @@ class WebhooksAPI:
         transaction_types: list, 
         account_addresses: list, 
         webhook_type: str, 
+        txn_status: str="all",
         auth_header: str=None
         ):
 
@@ -56,9 +59,10 @@ class WebhooksAPI:
             "webhookURL": webhook_url,
             "transactionTypes": transaction_types,
             "accountAddresses": account_addresses,
-            "webhookType": webhook_type
+            "webhookType": webhook_type,
+            "txn_status": txn_status
         }
-
+    
         if auth_header:
             payload["authHeader"] = auth_header
 

--- a/src/helius/webhooks.py
+++ b/src/helius/webhooks.py
@@ -23,7 +23,7 @@ class WebhooksAPI:
             "transactionTypes": transaction_types,
             "accountAddresses": account_addresses,
             "webhookType": webhook_type,
-            "txn_status": txn_status
+            "txnStatus": txn_status
         }
         if auth_header:
             payload["authHeader"] = auth_header
@@ -60,7 +60,7 @@ class WebhooksAPI:
             "transactionTypes": transaction_types,
             "accountAddresses": account_addresses,
             "webhookType": webhook_type,
-            "txn_status": txn_status
+            "txnStatus": txn_status
         }
     
         if auth_header:


### PR DESCRIPTION
This pull request adds support for the `txn_status` parameter in the `create_webhook` and `edit_webhook` methods of the `WebhooksAPI` class. This change allows users to specify the transaction status filter (`all`, `success`, `failed`) when setting up and modifying webhooks, as outlined in the Helius API documentation.

### Changes:
- Modified `create_webhook` and `edit_webhook` methods to accept an additional `txn_status` parameter.
- Set the default value for txn_status to "all"
- Updated method signatures and payload construction to incorporate the new parameter.

This enhancement addresses the need discussed in Issue #3 and aligns with the functionality provided by the Helius API. Please review the changes and let me know if any adjustments are required.

Thank you for considering this contribution to the Helius SDK.
