### PR TITLE
Update utility.py > _make_delete_request to handle missing response c…

### DIFF
--- a/src/helpers/utility.py
+++ b/src/helpers/utility.py
@@ -23,7 +23,15 @@ def _make_put_request(url, payload):
 
 def _make_delete_request(url):
     response = requests.delete(url)
+    # Check if the response contains any content
     if response.status_code == 200:
-        return response.json()
+        try:
+            # Try to parse JSON only if there is content
+            if response.text.strip():  # Checks if response text is not empty
+                return response.json()
+            else:
+                return None
+        except JSONDecodeError:
+            raise ValueError("Received unexpected response format from API")
     else:
-        raise ValueError(f'Error: {response.status_code}: {response.content}')
+        response.raise_for_status()  # Handle other HTTP errors


### PR DESCRIPTION
Helius doesn't return any response content when deleting a webhook.

As a result, when using WebhooksAPI to delete a hook, a JSONDecoderError is thrown.

This can interrupt for loops and other processes if not handled gracefully.

I've modified the helpers.utility function to handle this error more gracefully and return None if there is no response content.